### PR TITLE
Merge "hotfix/profile" to develop-v3

### DIFF
--- a/BeatCross/Views/ProfileView.swift
+++ b/BeatCross/Views/ProfileView.swift
@@ -193,7 +193,8 @@ struct ProfileView: View {
               let rootVC = window.rootViewController else { return }
 
         let spotifyVC = SpotifySearchViewController()
-        
+        spotifyVC.modalPresentationStyle = .fullScreen // ✅ フルスクリーンで開く
+
         // ✅ `onSongSelected` クロージャを設定
         spotifyVC.onSongSelected = { selectedSong, selectedArtist in
             DispatchQueue.main.async {
@@ -208,13 +209,18 @@ struct ProfileView: View {
                     "artists": [selectedArtist],
                     "savedAt": Timestamp(date: Date())
                 ]
-                userRef.setData(["favorite_song": newSong], merge: true)
+                userRef.setData(["favorite_song": newSong], merge: true) { error in
+                    if error == nil {
+                        DispatchQueue.main.async {
+                            // ✅ 更新後に ProfileView を再読み込み
+                            self.fetchUserProfile()
+                            spotifyVC.dismiss(animated: true)
+                        }
+                    }
+                }
             }
-            
-            spotifyVC.dismiss(animated: true)
         }
 
-        // ✅ モーダルで表示
         rootVC.present(spotifyVC, animated: true)
     }
     

--- a/BeatCross/Views/SpotifySearchViewController.swift
+++ b/BeatCross/Views/SpotifySearchViewController.swift
@@ -104,6 +104,11 @@ class SpotifySearchViewController: UIViewController, UITableViewDataSource, UITa
         }
 
         tableView.deselectRow(at: indexPath, animated: true)
+        // ✅ onSongSelected クロージャを呼び出して ProfileView にデータを送る
+            onSongSelected?(selectedTrack.name, selectedTrack.artists.map { $0.name }.joined(separator: ", "))
+
+            // ✅ 画面を閉じる
+            dismiss(animated: true, completion: nil)
     }
 
     // MARK: - HomeView への遷移処理


### PR DESCRIPTION
ProfileViewの機能改善をマージ

- `SpotifySearchViewController` を正しく開くよう修正
- お気に入り曲を選択後に Firestore に即時更新
- 更新後も `ProfileView` に留まり、最新の曲情報を反映
- モーダルの表示方法を `fullScreen` に変更し、スムーズな画面遷移を実現